### PR TITLE
Add prompt: create-github-pull-request-from-specification

### DIFF
--- a/prompts/create-github-pull-request-from-specification.prompt.md
+++ b/prompts/create-github-pull-request-from-specification.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create GitHub Pull Request for feature request from specification file using pull_request_template.md template.'
-tools: ['codebase', 'search', 'github', 'get_pull_request', 'create_pull_request', 'update_pull_request', 'get_pull_request_diff']
+tools: ['codebase', 'search', 'github', 'get_pull_request', 'create_pull_request', 'update_pull_request', 'get_pull_request_diff', 'update_issues]
 ---
 # Create GitHub Pull Request from Specification
 
@@ -13,8 +13,9 @@ Create GitHub Issue for the specification at `${workspaceFolder}/.github/pull_re
 2. Create Pull request draft template by using 'create_pull_request' tool on to `${input:targetBranch}`. and make sure don't have any pull request of current branch was exist `get_pull_request`. If has continue to step 4, and skip step 3.
 3. Get change in pull request draft was created by using 'get_pull_request_diff' tool. To anaylytic infomation was change in Pull Request draft was create before.
 4. Update Pull Request body was created in previous step by 'update_pull_request' tool. To update infomation exist to body, title with template using pull_request_template.md was get in first step.
-5. Switch from draft to ready for review by using 'update_pull_request' tool. To update state of pull request.
-6. Response URL Pull request was create to user.
+5. Switch from draft to ready for review by using 'update_pull_request' tool. To update state of pull request. 
+6. Using 'get_me' to get username of person was created pull request and assign to `update_issue` tool. To assign pull request
+7. Response URL Pull request was create to user.
 
 ## Requirements
 - Single issue for the complete specification


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [x] I have run `node update-readme.js` and verified that `README.md` is up to date.

---

## Description

This pull request adds the prompt file `prompts/create-github-pull-request-from-specification.prompt.md` which automates the creation of GitHub Pull Requests from specification files using the `.github/pull_request_template.md` template. The process is described in the prompt and ensures all requirements are met for contributing new features or instructions.

---

## Type of Contribution

- [x] New prompt file.

---

## Additional Notes

- The prompt follows the required process and template.
- All checklist items have been verified.
- Ready for review and merge.

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
